### PR TITLE
ns snippet automatically completing the namespace name

### DIFF
--- a/ns
+++ b/ns
@@ -1,4 +1,4 @@
 #name: ns
 # --
-(ns ${1:name}
+(ns `(clojure-expected-ns)`
   $0)


### PR DESCRIPTION
If this repository is not only for your own use but for all Clojure programmers which use yasnippet, then please accept this request which makes the ns snippet insert automatically the namespace name. This works with the latest clojure-mode.el
