### PR TITLE
defn: No trailing whitespace when you accept docstring.

### DIFF
--- a/defn
+++ b/defn
@@ -1,6 +1,6 @@
 #name: defn
 # --
-(defn ${1:name} ${2:
+(defn ${1:name}${2:
   "${3:doc-string}"
-  }[${4:arg-list}]
+ } [${4:arg-list}]
   $0)


### PR DESCRIPTION
Just a minor tweak to remove trailing whitespace from defn, when you keep the docstring.
