### PR TITLE
Added a note about depreciation of this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# Warning
+
+**************************************************************************
+
+**NOTE:** these snippets are **no longer** actively maintained. For
+the latest actively maintained snippets, organised into a package
+see [https://github.com/mpenet/clojure-snippets](https://github.com/mpenet/clojure-snippets)
+
+This repo is kept only for reference purposes
+
+**************************************************************************
+
+# Previously
+
 Install yasnippet via the Emacs package manager.
 
 Then:


### PR DESCRIPTION
Note added to the README in order to warn the users not to use these
snippets but that they should go to the actively maintained package's
repo.

This was based off the brief discussion we had yesterday.

Thank you
